### PR TITLE
Implement true, false builtins

### DIFF
--- a/builtin/builtin.c
+++ b/builtin/builtin.c
@@ -20,8 +20,10 @@ static const struct builtin builtins[] = {
 	{ "cd", builtin_cd, false },
 	{ "eval", builtin_eval, true },
 	{ "exit", builtin_exit, true },
+	{ "false", builtin_false, false },
 	{ "set", builtin_set, true },
 	{ "times", builtin_times, true },
+	{ "true", builtin_true, false },
 };
 
 static int builtin_compare(const void *_a, const void *_b) {

--- a/builtin/false.c
+++ b/builtin/false.c
@@ -1,0 +1,7 @@
+#include <mrsh/shell.h>
+#include <stdlib.h>
+#include "builtin.h"
+
+int builtin_false(struct mrsh_state *state, int argc, char *argv[]) {
+	return EXIT_FAILURE;
+}

--- a/builtin/true.c
+++ b/builtin/true.c
@@ -1,0 +1,7 @@
+#include <mrsh/shell.h>
+#include <stdlib.h>
+#include "builtin.h"
+
+int builtin_true(struct mrsh_state *state, int argc, char *argv[]) {
+	return EXIT_SUCCESS;
+}

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -16,6 +16,8 @@ int builtin_eval(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_source(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_times(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_set(struct mrsh_state *state, int argc, char *argv[]);
+int builtin_true(struct mrsh_state *state, int argc, char *argv[]);
+int builtin_false(struct mrsh_state *state, int argc, char *argv[]);
 
 const char *print_options(struct mrsh_state *state);
 

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,8 @@ lib_mrsh = library(
 		'builtin/set.c',
 		'builtin/source.c',
 		'builtin/times.c',
+		'builtin/true.c',
+		'builtin/false.c',
 		'hashtable.c',
 		'parser/parser.c',
 		'parser/program.c',


### PR DESCRIPTION
I saw your post on Mastodon inviting to contribute to mrsh, so I went ahead and wrote the most easy builtins I saw in your list ;)

(Actually, I'm taking a pause on a very stressful project with a burnt deadline, so I went to do something meaningful instead of getting into depression.)

`true` and `false` are implemented in terms of `EXIT_SUCCESS` and `EXIT_FAILURE` respectively, similar to how `:` is implemented.

This shouldn't be a significant contribution, but I look forward to contributing more to mrsh!