### PR TITLE
builtin/getopts: implement getopts builtin

### DIFF
--- a/builtin/builtin.c
+++ b/builtin/builtin.c
@@ -22,6 +22,7 @@ static const struct builtin builtins[] = {
 	{ "exit", builtin_exit, true },
 	{ "export", builtin_export, true },
 	{ "false", builtin_false, false },
+	{ "getopts", builtin_getopts, false },
 	{ "pwd", builtin_pwd, false },
 	{ "read", builtin_read, false },
 	{ "readonly", builtin_export, true },

--- a/builtin/getopts.c
+++ b/builtin/getopts.c
@@ -1,0 +1,89 @@
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <mrsh/buffer.h>
+#include <mrsh/shell.h>
+#include <limits.h>
+#include "builtin.h"
+
+static const char read_usage[] = "usage: getopts optstring name [arg...]\n";
+
+int builtin_getopts(struct mrsh_state *state, int argc, char *argv[]) {
+	if (argc < 3) {
+		fprintf(stderr, read_usage);
+		return EXIT_FAILURE;
+	}
+	
+	int optc;
+	char **optv;
+	if (argc > 3) {
+		optc = argc - 2;
+		optv = &argv[2];
+	} else {
+		optc = state->argc;
+		optv = state->argv;
+	}
+	char *optstring = argv[1];
+	
+	const char *optind_str = mrsh_env_get(state, "OPTIND", NULL);
+	if (optind_str == NULL) {
+		fprintf(stderr, "getopts: OPTIND is not defined\n");
+		return EXIT_FAILURE;
+	}
+	char *endptr;
+	long optind_long = strtol(optind_str, &endptr, 10);
+	if (endptr[0] != '\0' || optind_long <= 0 || optind_long > INT_MAX) {
+		fprintf(stderr, "getopts: OPTIND is not a positive integer\n");
+		return EXIT_FAILURE;
+	}
+	optind = (int)optind_long;
+	
+	optopt = 0;
+	int opt = getopt(optc, optv, optstring);
+	
+	char optind_fmt[16];
+	snprintf(optind_fmt, sizeof(optind_fmt), "%d", optind);
+	mrsh_env_set(state, "OPTIND", optind_fmt, MRSH_VAR_ATTRIB_NONE);
+	
+	if (optopt != 0) {
+		if (opt == ':') {
+			char value[] = {(char)optopt, '\0'};
+			mrsh_env_set(state, "OPTARG", value, MRSH_VAR_ATTRIB_NONE);
+		} else if (optstring[0] != ':') {
+			mrsh_env_unset(state, "OPTARG");
+		} else {
+			// either missing option-argument or unknown option character
+			// in the former case, unset OPTARG
+			// in the latter case, set OPTARG to optopt
+			bool opt_exists = false;
+			size_t len = strlen(optstring);
+			for (size_t i = 0; i < len; ++i) {
+				if (optstring[i] == optopt) {
+					opt_exists = true;
+					break;
+				}
+			}
+			if (opt_exists) {
+				mrsh_env_unset(state, "OPTARG");
+			} else {
+				char value[] = {(char)optopt, '\0'};
+				mrsh_env_set(state, "OPTARG", value, MRSH_VAR_ATTRIB_NONE);
+			}
+		}
+	} else if (optarg != NULL) {
+		mrsh_env_set(state, "OPTARG", optarg, MRSH_VAR_ATTRIB_NONE);
+	} else {
+		mrsh_env_unset(state, "OPTARG");
+	}
+	
+	char value[] = {opt == -1 ? (char)'?' : (char)opt, '\0'};
+	mrsh_env_set(state, argv[2], value, MRSH_VAR_ATTRIB_NONE);
+	
+	if (opt == -1) {
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -14,6 +14,7 @@ int builtin_colon(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_exit(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_export(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_eval(struct mrsh_state *state, int argc, char *argv[]);
+int builtin_getopts(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_pwd(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_read(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_shift(struct mrsh_state *state, int argc, char *argv[]);

--- a/main.c
+++ b/main.c
@@ -95,6 +95,8 @@ int main(int argc, char *argv[]) {
 		getcwd(cwd, PATH_MAX);
 		mrsh_env_set(&state, "PWD", cwd, MRSH_VAR_ATTRIB_EXPORT);
 	}
+	
+	mrsh_env_set(&state, "OPTIND", "1", MRSH_VAR_ATTRIB_NONE);
 
 	struct mrsh_parser *parser = mrsh_parser_create(state.input);
 	mrsh_parser_set_alias(parser, get_alias, &state);

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ lib_mrsh = library(
 		'builtin/eval.c',
 		'builtin/exit.c',
 		'builtin/export.c',
+		'builtin/getopts.c',
 		'builtin/pwd.c',
 		'builtin/read.c',
 		'builtin/set.c',


### PR DESCRIPTION
https://web.archive.org/web/20180906014022/http://pubs.opengroup.org/onlinepubs/9699919799/utilities/getopts.html

- not sure how to get the "shell positional arguments" (in the cases the user does not pass any args to getopts apart from the optstring and the variable name), i used `state->argv` and `state->argc` but did not try it
- i think getopts returns exactly the same outputs when either an option-argument is missing and the optstring does not start with a colon, or an unknown option character was found. so to find out which case we're in, we have to iterate all the options in the optstring to know if the option is there (so the case is "missing an argument"), or not ("unknown option"). not very expensive but not perfect. (we need to know which case we're in b/c we need to set or unset a variable depending on the case)
- i have checked a lot of corner cases against bash, and compared their environment variables and stderr outputs, with commands like `getopts a: test -a`, `getopts :a: test -a`, `getopts a test -v`, `getopts :a test -v`. i think my implementation is correct wrt most corner cases but i may have forgotten a few of them