### PR TITLE
implement hash builtin, hash paths on simple_task

### DIFF
--- a/builtin/builtin.c
+++ b/builtin/builtin.c
@@ -28,6 +28,7 @@ static const struct builtin builtins[] = {
 	{ "false", builtin_false, false },
 	{ "fg", builtin_fg, false },
 	{ "getopts", builtin_getopts, false },
+	{ "hash", builtin_hash, false },
 	{ "pwd", builtin_pwd, false },
 	{ "read", builtin_read, false },
 	{ "readonly", builtin_export, true },

--- a/builtin/hash.c
+++ b/builtin/hash.c
@@ -1,0 +1,73 @@
+#define _POSIX_C_SOURCE 200809L
+#include <mrsh/getopt.h>
+#include <mrsh/shell.h>
+#include <shell/path.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "builtin.h"
+
+static const char hash_usage[] = "usage: hash -r|utility...\n";
+
+static void print_entry(const char *key, void *value, void *user_data)
+{
+	struct mrsh_cached_command_path *entry = value;
+	unsigned int *count_entries = (unsigned int *)user_data;
+
+	if (*count_entries == 0) {
+		puts("hits\tcommand");
+	}
+	printf("%4d\t%s\n", entry->hits, entry->command);
+
+	(*count_entries) ++;
+}
+
+
+static void print_table(struct mrsh_state *state) {
+	unsigned int entries = 0;
+	mrsh_hashtable_for_each(&state->cached_command_paths, print_entry, &entries);
+}
+
+static void add_command_path(struct mrsh_state *state, const char *command) {
+	const char *path = expand_exec_path(state, command);
+
+	if (path == NULL) {
+		fprintf(stderr, "hash: command not found: %s\n", command);
+		return;
+	}
+
+	struct mrsh_hashtable *paths = &state->cached_command_paths;
+	struct mrsh_cached_command_path *entry =
+		(struct mrsh_cached_command_path *)mrsh_hashtable_get(paths, command);
+
+	entry->hits --;
+}
+
+int builtin_hash(struct mrsh_state *state, int argc, char *argv[]) {
+	mrsh_optind = 0;
+	int opt;
+	while ((opt = mrsh_getopt(argc, argv, ":r")) != -1) {
+		switch (opt) {
+		case 'r':
+			clear_exec_path_cache(state);
+			return 0;
+		default:
+			fprintf(stderr, "hash: unknown option -- %c\n", mrsh_optopt);
+			fprintf(stderr, hash_usage);
+			return 1;
+		}
+	}
+
+	if (argc == 1) {
+		print_table(state);
+		mrsh_optind ++;
+		return 0;
+	}
+
+	for (int i = 1; i < argc; i++) {
+		add_command_path(state, argv[i]);
+		mrsh_optind ++;
+	}
+
+	return 0;
+}

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -20,6 +20,7 @@ int builtin_exit(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_export(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_false(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_fg(struct mrsh_state *state, int argc, char *argv[]);
+int builtin_hash(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_getopts(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_pwd(struct mrsh_state *state, int argc, char *argv[]);
 int builtin_read(struct mrsh_state *state, int argc, char *argv[]);

--- a/include/mrsh/shell.h
+++ b/include/mrsh/shell.h
@@ -75,6 +75,11 @@ struct mrsh_function {
 	struct mrsh_command *body;
 };
 
+struct mrsh_cached_command_path {
+	unsigned int hits;
+	char *command;
+};
+
 struct mrsh_call_frame {
 	char **argv;
 	int argc;
@@ -98,6 +103,7 @@ struct mrsh_state {
 	struct mrsh_hashtable variables; // struct mrsh_variable *
 	struct mrsh_hashtable aliases; // char *
 	struct mrsh_hashtable functions; // struct mrsh_function *
+	struct mrsh_hashtable cached_command_paths;
 	struct mrsh_array processes;
 	int last_status;
 

--- a/include/shell/path.h
+++ b/include/shell/path.h
@@ -9,4 +9,7 @@
  * match. Fully qualified paths are returned as-is. */
 const char *expand_path(struct mrsh_state *state, const char *file, bool exec);
 
+const char *expand_exec_path(struct mrsh_state *state, const char *command);
+void clear_exec_path_cache(struct mrsh_state *state);
+
 #endif

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ lib_mrsh = library(
 		'builtin/false.c',
 		'builtin/fg.c',
 		'builtin/getopts.c',
+		'builtin/hash.c',
 		'builtin/pwd.c',
 		'builtin/read.c',
 		'builtin/set.c',

--- a/shell/task/simple_command.c
+++ b/shell/task/simple_command.c
@@ -36,7 +36,7 @@ static struct mrsh_job *put_into_process_group(struct context *ctx, pid_t pid) {
 
 static int run_process(struct context *ctx, struct mrsh_simple_command *sc,
 		char **argv) {
-	const char *path = expand_path(ctx->state, argv[0], true);
+	const char *path = expand_exec_path(ctx->state, argv[0]);
 	if (!path) {
 		fprintf(stderr, "%s: not found\n", argv[0]);
 		return -1;


### PR DESCRIPTION
The only thing missing is to clear the command path cache when the `PATH` variable is set.