### PR TITLE
configure: Only add -I CFLAGS from readline

### DIFF
--- a/configure
+++ b/configure
@@ -252,13 +252,8 @@ fi
 
 if [ $use_readline -eq 1 ]
 then
-	append_cflags $($pkg_config --cflags $readline)
+	append_cflags $($pkg_config --cflags-only-I $readline)
 	append_libs $($pkg_config --libs $readline)
-	if [ "$readline" = "readline" ]
-	then
-		# Undo GNU_SOURCE
-		append_cflags -U_GNU_SOURCE
-	fi
 fi
 
 printf "Creating $outdir/config.mk... "


### PR DESCRIPTION
Adding the readline CFLAGS to our own can define undesired symbols,
like for _GNU_SOURCE and _XOPEN_SOURCE.
We take extra precautions to remove _GNU_SOURCE
but a stray _XOPEN_SOURCE can break our build due to redefined symbols.

This change modifies the pkgconfig invocation
to only add the -I CFLAGS of the readline package,
which don't include symbol definitions
and spares us the trouble of having to remove them.

Fixes #115