### PR TITLE
Fix arithmetic parsing with spaces/parentheses

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -61,6 +61,8 @@ struct mrsh_parser {
 
 	mrsh_parser_alias_func alias;
 	void *alias_user_data;
+
+	int arith_nested_parens;
 };
 
 typedef struct mrsh_word *(*word_func)(struct mrsh_parser *parser, char end);

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -57,7 +57,6 @@ static struct mrsh_parser *parser_create(void) {
 	struct mrsh_parser *parser = calloc(1, sizeof(struct mrsh_parser));
 	parser->fd = -1;
 	parser->pos.line = parser->pos.column = 1;
-	parser->arith_nested_parens = 0;
 	return parser;
 }
 

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -57,6 +57,7 @@ static struct mrsh_parser *parser_create(void) {
 	struct mrsh_parser *parser = calloc(1, sizeof(struct mrsh_parser));
 	parser->fd = -1;
 	parser->pos.line = parser->pos.column = 1;
+	parser->arith_nested_parens = 0;
 	return parser;
 }
 

--- a/parser/word.c
+++ b/parser/word.c
@@ -745,7 +745,6 @@ struct mrsh_word *arithmetic_word(struct mrsh_parser *parser, char end) {
 	struct mrsh_array children = {0};
 	struct mrsh_buffer buf = {0};
 	struct mrsh_position child_begin = {0};
-	int nested_parens = 0;
 
 	while (true) {
 		if (!mrsh_position_valid(&child_begin)) {
@@ -756,7 +755,7 @@ struct mrsh_word *arithmetic_word(struct mrsh_parser *parser, char end) {
 		c = next[0];
 		if (c == '\0' || c == '\n' || c == ';'
 				|| isblank(c)
-				|| (strcmp(next, "))") == 0 && nested_parens == 0)) {
+				|| (strcmp(next, "))") == 0 && parser->arith_nested_parens == 0)) {
 			break;
 		}
 
@@ -816,14 +815,14 @@ struct mrsh_word *arithmetic_word(struct mrsh_parser *parser, char end) {
 		}
 
 		if (c == '(') {
-			nested_parens++;
+			parser->arith_nested_parens++;
 		} else if (c == ')') {
-			if (nested_parens == 0) {
+			if (parser->arith_nested_parens == 0) {
 				parser_set_error(parser, "unmatched closing parenthesis "
 					"in arithmetic expression");
 				return NULL;
 			}
-			nested_parens--;
+			parser->arith_nested_parens--;
 		}
 
 		parser_read_char(parser);

--- a/parser/word.c
+++ b/parser/word.c
@@ -367,6 +367,7 @@ static struct mrsh_word_arithmetic *expect_word_arithmetic(
 	c = parser_read_char(parser);
 	assert(c == '(');
 
+	parser->arith_nested_parens = 0;
 	struct mrsh_word *body = word_list(parser, 0, arithmetic_word);
 	if (body == NULL) {
 		if (!mrsh_parser_error(parser, NULL)) {

--- a/parser/word.c
+++ b/parser/word.c
@@ -737,7 +737,10 @@ struct mrsh_word *arithmetic_word(struct mrsh_parser *parser, char end) {
 	char c = parser_peek_char(parser);
 	if (c == ')') {
 		parser_peek(parser, next, sizeof(*next) * 2);
-		if (!strcmp(next, "))")) {
+		// If arith_nested_parens != 0, we might be closing an expr.
+		// E.g. $(((1+1 )))
+		//              ^
+		if (!strcmp(next, "))") && parser->arith_nested_parens == 0) {
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Nice project. This is for #161. Fixing it exposed another bug which is also now fixed. I think the commit messages and the comment in the second diff should explain well enough.

I don't like the idea of putting `arith_nested_parens` in the `parser` struct though. It can't be `static` to `arithmetic_word` because that is called in a loop by a general function. It can be `static` to the file, if that is more preferred.