### PR TITLE
Extra checks to ensure we don't clobber std fds

### DIFF
--- a/shell/task/pipeline.c
+++ b/shell/task/pipeline.c
@@ -74,7 +74,7 @@ int run_pipeline(struct mrsh_context *ctx, struct mrsh_pipeline *pl) {
 				close(next_stdin);
 			}
 
-			if (i > 0) {
+			if (i > 0 && cur_stdin != STDIN_FILENO) {
 				if (dup2(cur_stdin, STDIN_FILENO) < 0) {
 					fprintf(stderr, "failed to duplicate stdin: %s\n",
 						strerror(errno));
@@ -83,7 +83,7 @@ int run_pipeline(struct mrsh_context *ctx, struct mrsh_pipeline *pl) {
 				close(cur_stdin);
 			}
 
-			if (i < pl->commands.len - 1) {
+			if (i < pl->commands.len - 1 && cur_stdout != STDOUT_FILENO) {
 				if (dup2(cur_stdout, STDOUT_FILENO) < 0) {
 					fprintf(stderr, "failed to duplicate stdout: %s\n",
 						strerror(errno));

--- a/shell/task/task.c
+++ b/shell/task/task.c
@@ -32,8 +32,10 @@ static int run_subshell(struct mrsh_context *ctx, struct mrsh_array *array) {
 					strerror(errno));
 				exit(1);
 			}
-			dup2(fd, STDIN_FILENO);
-			close(fd);
+			if (fd != STDIN_FILENO) {
+				dup2(fd, STDIN_FILENO);
+				close(fd);
+			}
 		}
 
 		int ret = run_command_list_array(ctx, array);
@@ -358,8 +360,10 @@ int run_command_list_array(struct mrsh_context *ctx, struct mrsh_array *array) {
 							strerror(errno));
 						exit(1);
 					}
-					dup2(fd, STDIN_FILENO);
-					close(fd);
+					if (fd != STDIN_FILENO) {
+						dup2(fd, STDIN_FILENO);
+						close(fd);
+					}
 				}
 
 				int ret = run_and_or_list(&child_ctx, list->and_or_list);

--- a/shell/task/word.c
+++ b/shell/task/word.c
@@ -103,8 +103,10 @@ static int run_word_command(struct mrsh_context *ctx, struct mrsh_word **word_pt
 	} else if (pid == 0) {
 		close(fds[0]);
 
-		dup2(fds[1], STDOUT_FILENO);
-		close(fds[1]);
+		if (fds[1] != STDOUT_FILENO) {
+			dup2(fds[1], STDOUT_FILENO);
+			close(fds[1]);
+		}
 
 		init_job_child_process(ctx->state);
 


### PR DESCRIPTION
Fix for https://github.com/emersion/mrsh/issues/171

Adds additional defensive checks when overriding stdin/stdout so they aren't inadvertently closed leading to "invalid file descriptor" errors.