### PR TITLE
Fix crash in set builtin

### DIFF
--- a/builtin/set.c
+++ b/builtin/set.c
@@ -193,8 +193,11 @@ static int set(struct mrsh_state *state, int argc, char *argv[],
 		if (init_args != NULL) {
 			argv_0 = strdup(argv[i++]);
 			init_args->command_file = argv_0;
-		} else {
+		} else if (state->frame->argv) {
 			argv_0 = strdup(state->frame->argv[0]);
+		} else {
+			fprintf(stderr, set_usage);
+			return 1;
 		}
 		argv_free(state->frame->argc, state->frame->argv);
 		state->frame->argc = argc - i + 1;


### PR DESCRIPTION
A command such as `set gr` would crash in arg handling here:
```
* thread #18, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000100019dae tersh`set(state=0x000000010604c600, argc=2, argv=0x0000000105413380, init_args=0x0000000000000000, populated_opts=0x0000700009239a9c) at set.c:197:20
   194 				argv_0 = strdup(argv[i++]);
   195 				init_args->command_file = argv_0;
   196 			} else {
-> 197 				argv_0 = strdup(state->frame->argv[0]);
   198 			}
   199 			argv_free(state->frame->argc, state->frame->argv);
   200 			state->frame->argc = argc - i + 1;
```
An additional check has been added to print the usage text and return an error in this case. 