### PR TITLE
Job control improvements

### DIFF
--- a/shell/job.c
+++ b/shell/job.c
@@ -226,7 +226,7 @@ static bool _job_wait(struct mrsh_state *state, pid_t pid, int options) {
 	// shell. Child processes want to block until their own children have
 	// terminated.
 	if (!priv->child) {
-		options |= WUNTRACED;
+		options |= WUNTRACED | WCONTINUED;
 	}
 
 	while (true) {
@@ -294,12 +294,14 @@ bool refresh_jobs_status(struct mrsh_state *state) {
 
 	for (size_t i = 0; i < priv->jobs.len; ++i) {
 		struct mrsh_job *job = priv->jobs.data[i];
-		struct mrsh_process *proc = job_get_running_process(job);
-		if (proc == NULL) {
-			continue;
-		}
-		if (!_job_wait(job->state, proc->pid, WNOHANG)) {
-			return false;
+		for (size_t j = 0; j < job->processes.len; ++j) {
+			struct mrsh_process *proc = job->processes.data[j];
+			int status = process_poll(proc);
+			if (status == TASK_STATUS_WAIT || status == TASK_STATUS_STOPPED) {
+				if (!_job_wait(job->state, proc->pid, WNOHANG)) {
+					return false;
+				}
+			}
 		}
 	}
 
@@ -326,9 +328,7 @@ static void update_job(struct mrsh_state *state, pid_t pid, int stat) {
 		struct mrsh_job *job = priv->jobs.data[i];
 
 		int status = job_poll(job);
-		if (status >= 0) {
-			job_queue_notification(job);
-		}
+		job_queue_notification(job);
 		if (status != TASK_STATUS_WAIT && job->pgid > 0) {
 			job_set_foreground(job, false, false);
 		}

--- a/shell/job.c
+++ b/shell/job.c
@@ -226,7 +226,11 @@ static bool _job_wait(struct mrsh_state *state, pid_t pid, int options) {
 	// shell. Child processes want to block until their own children have
 	// terminated.
 	if (!priv->child) {
+#ifdef WCONTINUED
 		options |= WUNTRACED | WCONTINUED;
+#else
+		options |= WUNTRACED;
+#endif
 	}
 
 	while (true) {

--- a/shell/process.c
+++ b/shell/process.c
@@ -71,11 +71,15 @@ void update_process(struct mrsh_state *state, pid_t pid, int stat) {
 	}
 
 	if (WIFEXITED(stat) || WIFSIGNALED(stat)) {
+		proc->stopped = false;
 		proc->terminated = true;
 		proc->stat = stat;
 	} else if (WIFSTOPPED(stat)) {
 		proc->stopped = true;
 		proc->signal = WSTOPSIG(stat);
+	} else if (WIFCONTINUED(stat)) {
+		proc->stopped = false;
+		proc->signal = SIGCONT;
 	} else {
 		abort();
 	}

--- a/shell/process.c
+++ b/shell/process.c
@@ -77,9 +77,11 @@ void update_process(struct mrsh_state *state, pid_t pid, int stat) {
 	} else if (WIFSTOPPED(stat)) {
 		proc->stopped = true;
 		proc->signal = WSTOPSIG(stat);
+#ifdef WCONTINUED
 	} else if (WIFCONTINUED(stat)) {
 		proc->stopped = false;
 		proc->signal = SIGCONT;
+#endif
 	} else {
 		abort();
 	}

--- a/test/jobs.sh
+++ b/test/jobs.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -me
+
+sleep 10&
+echo "$(jobs)"
+echo "$(jobs -p %1)"
+[ -z "$(jobs %1)" ]
+jobs %1 | grep "Running"
+kill -STOP $(jobs -p %1)
+jobs %1 | grep "SIGSTOP"
+kill $(jobs -p %1)
+[ -z "$(jobs %1)" ]
+
+sleep 10&
+kill -STOP $(jobs -p %1)
+kill -CONT $(jobs -p %1)
+jobs %1 | grep "Running"
+kill $(jobs -p %1)
+[ -z "$(jobs %1)" ]


### PR DESCRIPTION
Draft fix for https://github.com/emersion/mrsh/issues/174

- Fixes SIGSTOP/SIGCONT signal handling
- removes intermediate fork in `run_command_list_array` for background jobs so that actual child state can be tracked properly
- improves reliability of job status updates and notifications

I included a jobs.sh test script, but it isn't incorporated into the test target because it causes it hang. Running it separately it works fine though and exits cleanly. Also not sure if these tests are only for parity, if so then it needs more attention since I didn't attempt to run it in other shells yet.

See also XXX comments inline. In particular the one about the general fork abstraction. I feel like forking a job process could be generalized since it happens in several places.