### PR TITLE
Improved job status notifications for SIGSTOP/SIGCONT

### DIFF
--- a/shell/process.c
+++ b/shell/process.c
@@ -71,11 +71,17 @@ void update_process(struct mrsh_state *state, pid_t pid, int stat) {
 	}
 
 	if (WIFEXITED(stat) || WIFSIGNALED(stat)) {
+		proc->stopped = false;
 		proc->terminated = true;
 		proc->stat = stat;
 	} else if (WIFSTOPPED(stat)) {
 		proc->stopped = true;
 		proc->signal = WSTOPSIG(stat);
+#ifdef WCONTINUED
+	} else if (WIFCONTINUED(stat)) {
+		proc->stopped = false;
+		proc->signal = SIGCONT;
+#endif
 	} else {
 		abort();
 	}

--- a/test/jobs.sh
+++ b/test/jobs.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -me
+
+sleep 10&
+echo "$(jobs)"
+echo "$(jobs -p %1)"
+[ -z "$(jobs %1)" ]
+jobs %1 | grep "Running"
+kill -STOP $(jobs -p %1)
+jobs %1 | grep "SIGSTOP"
+kill $(jobs -p %1)
+[ -z "$(jobs %1)" ]
+
+sleep 10&
+kill -STOP $(jobs -p %1)
+kill -CONT $(jobs -p %1)
+jobs %1 | grep "Running"
+kill $(jobs -p %1)
+[ -z "$(jobs %1)" ]


### PR DESCRIPTION
Fix for: https://github.com/emersion/mrsh/issues/174

- Job notification on SIGCONT for supporting platforms
- `run_process()` no longer forks twice for background jobs, allowing detection of SIGSTOP/SIGCONT
- Added jobs.sh test script