### PR TITLE
Add support for building static executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ $(OUTDIR)/mrsh.pc:
 
 mrsh: $(OUTDIR)/libmrsh.a $(mrsh_objects)
 	@printf 'CCLD\t$@\n'
-	@$(CC) -o $@ $(LIBS) $(mrsh_objects) -L$(OUTDIR) -lmrsh
+	@$(CC) -o $@ $(LDFLAGS) $(LIBS) $(mrsh_objects) -L$(OUTDIR) -lmrsh
 
 highlight: $(OUTDIR)/libmrsh.a $(highlight_objects)
 	@printf 'CCLD\t$@\n'
-	@$(CC) -o $@ $(LIBS) $(highlight_objects) -L$(OUTDIR) -lmrsh
+	@$(CC) -o $@ $(LDFLAGS) $(LIBS) $(highlight_objects) -L$(OUTDIR) -lmrsh
 
 check: mrsh $(tests)
 	@for t in $(tests); do \

--- a/configure
+++ b/configure
@@ -10,6 +10,8 @@ LIBS=
 use_readline=-1
 readline=readline
 
+static=
+
 for arg
 do
 	case "$arg" in
@@ -22,6 +24,12 @@ do
 		--with-readline=*)
 			use_readline=1
 			readline=${arg#*=}
+			;;
+		--static)
+			static=$arg
+			;;
+		--dynamic)
+			static=
 			;;
 	esac
 done
@@ -181,6 +189,11 @@ test_ldflags() {
 
 mkdir -p "$outdir"
 
+if [ -n "$static" ]
+then
+	test_ldflags $static
+fi
+
 for flag in \
 	-g -std=c99 -pedantic -Werror -Wundef -Wlogical-op \
 	-Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self \
@@ -259,8 +272,8 @@ fi
 
 if [ $use_readline -eq 1 ]
 then
-	append_cflags $($pkg_config --cflags-only-I $readline)
-	append_libs $($pkg_config --libs $readline)
+	append_cflags $($pkg_config $static --cflags-only-I $readline)
+	append_libs $($pkg_config $static --libs $readline)
 fi
 
 printf "Creating %s/config.mk... " "$outdir"


### PR DESCRIPTION
This fixes the following issues:
* linked objects do not use LDFLAGS
* pkg-config is not queried appropriately depending on the desired linkage
* there's no way to configure/deconfigure static linking
  (except by setting LDFLAGS, which won't work due to the prior two)

There are many ways of fixing these, but I went for the minimally intrusive approach:
* any linked objects have `$(LDFLAGS)` in front of `$(LIBS)`
* configure has a --static and --dynamic flag
* --static is added to ldflags only if selected

If any changes are desired, please feel free to make them - what matters to me is the utility, moreso than the exact implementation details (so long as they accomplish the same things).
This patch is pretty small, so if licensing is a concern, please consider it CC0.