### PR TITLE
Makefile: update list of tests from meson build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,19 @@ public_includes=\
 		include/mrsh/shell.h
 
 tests=\
-		test/conformance/if.sh \
+		test/args.sh \
 		test/arithm.sh \
 		test/async.sh \
 		test/case.sh \
 		test/command.sh \
 		test/for.sh \
 		test/function.sh \
+		test/if.sh \
 		test/loop.sh \
 		test/pipeline.sh \
+		test/read.sh \
+		test/readonly.sh \
+		test/redir.sh \
 		test/return.sh \
 		test/subshell.sh \
 		test/syntax.sh \

--- a/test/if.sh
+++ b/test/if.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Reference stdout:
+# pass
+# pass
+# pass
+# pass
+# pass
+# pass
+
+echo "-> if..fi with true condition"
+if true
+then
+	echo pass
+fi
+
+echo "-> if..fi with false condition"
+if false
+then
+	echo >&2 "fail: This branch should not have run" && exit 1
+fi
+echo pass
+
+echo "-> if..else..fi with true condition"
+if true
+then
+	echo pass
+else
+	echo >&2 "fail: This branch should not have run" && exit 1
+fi
+
+echo "-> if..else..fi with false condition"
+if false
+then
+	echo >&2 "fail: This branch should not have run" && exit 1
+else
+	echo pass
+fi
+
+echo "-> if..else..fi with true condition"
+if true
+then
+	echo pass
+else
+	echo >&2 "fail: This branch should not have run" && exit 1
+fi
+
+echo "-> if..else..elif..fi with false condition"
+if false
+then
+	echo >&2 "fail: This branch should not have run" && exit 1
+elif true
+then
+	echo pass
+else
+	echo >&2 "fail: This branch should not have run" && exit 1
+fi
+
+echo "-> test exit status"
+if true
+then
+	( exit 10 )
+else
+	( exit 20 )
+fi
+[ $# -eq 10 ] || { echo >&2 "fail: Expected status code = 10" && exit 1; }
+if false
+then
+	( exit 10 )
+else
+	( exit 20 )
+fi
+[ $# -eq 20 ] || { echo >&2 "fail: Expected status code = 20" && exit 1; }
+
+echo "-> test alternate syntax"
+# These tests are only expected to parse, they do not make assertions
+if true; then true; fi
+if true; then true; else true; fi
+if true; then true; elif true; then true; else true; fi

--- a/test/meson.build
+++ b/test/meson.build
@@ -9,6 +9,7 @@ test_files = [
 	'command.sh',
 	'for.sh',
 	'function.sh',
+	'if.sh',
 	'loop.sh',
 	'pipeline.sh',
 	'read.sh',


### PR DESCRIPTION
Also bring back if.sh test. This was deleted from test/conformance in 845da7c4, but was not removed from Makefile breaking 'make check'. Bring it back to test/ directory as not really testing specific subclause of POSIX spec.

Fixes emersion/mrsh#194